### PR TITLE
fix(cors): enable cors for lambda proxy

### DIFF
--- a/lambdas/classifier/lambda_function.py
+++ b/lambdas/classifier/lambda_function.py
@@ -11,6 +11,11 @@ device = "cuda" if torch.cuda.is_available() else "cpu"
 model, preprocess = clip.load(model_path, jit=False, device=device)
 filename = "/tmp/downloaded_image.jpg"
 
+responseHeaders = {
+    'Content-Type': 'application/json',
+    'Access-Control-Allow-Headers': 'Content-Type',
+    'Access-Control-Allow-Origin': '*',
+}
 
 def handler(event, context):
     args = json.loads(event["body"])
@@ -43,7 +48,12 @@ def handler(event, context):
         print(f"Exception: {e}")
         import traceback
         traceback.print_exc()
-        raise
+        return {
+            'statusCode': 500,
+            'headers': responseHeaders,
+            'body': json.dumps(str(e)),
+            "isBase64Encoded": False
+        }
 
     result = {}
     for i in range(len(labels)):
@@ -53,9 +63,7 @@ def handler(event, context):
 
     return {
         'statusCode': 200,
-        'headers': {
-            'Content-Type': 'application/json'
-        },
+        'headers': responseHeaders,
         'body': json.dumps({
             'result': result
         }),

--- a/lib/clip-classifier-stack.ts
+++ b/lib/clip-classifier-stack.ts
@@ -42,6 +42,11 @@ export class ClipClassifierStack extends cdk.Stack {
         accessLogDestination: new apigw.LogGroupLogDestination(accessLogsLogGroup),
         accessLogFormat: apigw.AccessLogFormat.clf()
       },
+      defaultCorsPreflightOptions: {
+        allowHeaders: apigw.Cors.DEFAULT_HEADERS,
+        allowMethods: apigw.Cors.ALL_METHODS,
+        allowOrigins: apigw.Cors.ALL_ORIGINS
+      },
     });
 
     // Output the image URI


### PR DESCRIPTION
This PR enables CORS for the Lambda proxy integration.
* Configured `defaultCorsPreflightOptions` in the API Gateway `LambdaRestApi` construct
* Added the following headers to the Lambda response: 
  * `Access-Control-Allow-Origin`
  * `Access-Control-Allow-Headers`
  * `Content-Type`